### PR TITLE
feat: set release_status to production/stable

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/security-scanner/docs/",
   "client_documentation": "https://googleapis.dev/python/websecurityscanner/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559748",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-websecurityscanner",
   "distribution_name": "google-cloud-websecurityscanner",

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 Python Client for Web Security Scanner API
 ==========================================
 
-|alpha| |pypi| |versions| 
+|ga| |pypi| |versions| 
 
 `Web Security Scanner API`_: Web Security Scanner API (under development).
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+.. |ga| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-websecurityscanner.svg
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-websecurityscanner.svg

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ version = "0.4.0"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 
 extras = {}


### PR DESCRIPTION
Release-As: 1.0.0

Proposed release: **GA**

## Instructions

Check the lists below, adding tests / documentation as required. Once all the "required" boxes are ticked, please create a release and close this issue.

## Required

- [x] 28 days elapsed since last beta release with new API surface (last release on [1/30/2020](https://github.com/googleapis/python-websecurityscanner/releases/tag/v0.4.0))
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA

## Optional

- [ ] Most common / important scenarios have descriptive samples
- [ ] Public manual methods have at least one usage sample each (excluding overloads)
- [ ] Per-API README includes a full description of the API
- [ ] Per-API README contains at least one “getting started” sample using the most common API scenario
- [ ] Manual code has been reviewed by API producer
- [ ] Manual code has been reviewed by a DPE responsible for samples
- [ ] 'Client Libraries' page is added to the product documentation in 'APIs & Reference' section of the product's documentation on Cloud Site