### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "websecurityscanner",
     "name_pretty": "Cloud Security Scanner",
     "product_documentation": "https://cloud.google.com/security-scanner/docs/",
-    "client_documentation": "https://googleapis.dev/python/websecurityscanner/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/websecurityscanner/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559748",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Web Security Scanner API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-websecurityscanner.svg
    :target: https://pypi.org/project/google-cloud-websecurityscanner/
 .. _Web Security Scanner API: https://cloud.google.com/security-scanner
-.. _Client Library Documentation: https://googleapis.dev/python/websecurityscanner/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/websecurityscanner/latest
 .. _Product Documentation:  https://cloud.google.com/security-scanner
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.